### PR TITLE
[Fix] Spinner lifecycle fix

### DIFF
--- a/app/src/main/java/com/example/mediaapp/HomeFragment.kt
+++ b/app/src/main/java/com/example/mediaapp/HomeFragment.kt
@@ -209,6 +209,11 @@ class HomeFragment : Fragment() {
         }
     }
 
+    override fun onPause() {
+        super.onPause()
+        binding.homeSpnCategorySelect.dismiss()
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         scrollHandler.removeCallbacksAndMessages(null)


### PR DESCRIPTION
[Fix] Category Spinner를 펼친상태에서 다른 Fragment로 전환 시 spinner 메뉴가 계속해서 화면에 남던 현상 수정되었습니다